### PR TITLE
Make the XML namespaces variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This role also handles some initial Keycloak server configuration. This includes
 Before running this role following requirements have to be fulfilled:
 
 * Java JDK (version 8 or higher) for example with [geerlingguy.java](https://github.com/geerlingguy/ansible-role-java)
+* PIP, for example with [geerlingguy.pip](https://github.com/geerlingguy/ansible-role-java)
 * Running PostgreSQL with a user and database for Keycloak for example with [geerlingguy.postgresql](https://github.com/geerlingguy/ansible-role-postgresql)
 * In most cases also a reverse proxy configured doing the following:
   * Add `X-Forwarded-For` header
@@ -21,8 +22,8 @@ Before running this role following requirements have to be fulfilled:
 
 | Variable Name | Function | default | comment |
 | ------------- | -------- | ------- | ------- |
-| `keycloak_version` | Version of Keycloak going to be installed | `"12.0.4"` | The role is build for working with the default version. Try other versions with your own risk |
-| `keycloak_url` | URL of the Keycloak archive which is downloaded | `"https://downloads.jboss.org/keycloak/{{ keycloak_version }}/keycloak-{{ keycloak_version }}.zip"` | |
+| `keycloak_version` | Version of Keycloak going to be installed | `"13.0.0"` | The role is build for working with the default version. Try other versions with your own risk |
+| `keycloak_url` | URL of the Keycloak archive which is downloaded | `"https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/keycloak-{{ keycloak_version }}.zip"` | |
 | `keycloak_force_install` | Whether Keycloak should be (re-)installed ignoring the check if it is already installed | `false` | |
 | `keycloak_create_admin` | Whether a Keycloak admin user should be created | `false` | should be only run one time after first keycloak installation (no matter which version)  |
 | `keycloak_admin_user` | Username of the Keycloak admin user which is going to be created | `"admin"` | |
@@ -40,6 +41,18 @@ Before running this role following requirements have to be fulfilled:
 | `keycloak_config_dir` | Configuration directory of the Keycloak installation | `"{{ keycloak_jboss_home }}/standalone/configuration"` | (only change if you know what you're doing)  |
 | `keycloak_startup_timeout` | Time to wait Keycloak to start (given to SystemD service)  | `"300"` | in seconds | 
 | `keycloak_java_opts` | JAVA_OPTS used by Keycloak | `"-Xms256m -Xmx1024m"""` | if you run a large instance or experience problems you should have a look on this | 
+
+### Configuration files (optional)
+
+To adapt, depending on the Keycloak version.  
+Please, refer to the **xmlns** attributes in the **configuration/standalone.xml** file.
+
+| Variable Name | Function | default | comment |
+| ------------- | -------- | ------- | ------- |
+| `keycloak_config_ns_server` | XML namespace for the server element. | `"urn:jboss:domain:16.0"` |  |
+| `keycloak_config_ns_undertow` | XML namespace for the undertow subsystem. | `"urn:jboss:domain:undertow:12.0"` |  |
+| `keycloak_config_ns_subsystem_datasource` | XML namespace for the datasources subsystem. | `"urn:jboss:domain:datasources:6.0"` |  |
+| `keycloak_config_ns_subsystem_keycloak` | XML namespace for the Keycloak subsystem. | `"urn:jboss:domain:keycloak-server:1.1"` |  |
 
 ### Database (required)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General (required)
-keycloak_version: "12.0.4"
+keycloak_version: "13.0.0"
 keycloak_url: "https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/keycloak-{{ keycloak_version }}.zip"
 keycloak_force_install: false
 keycloak_create_admin: false
@@ -16,8 +16,14 @@ keycloak_config_dir: "{{ keycloak_jboss_home }}/standalone/configuration"
 keycloak_startup_timeout: "300"
 keycloak_java_opts: "-Xms256m -Xmx1024m"
 
+## Configuration files
+keycloak_config_ns_server: "urn:jboss:domain:16.0"
+keycloak_config_ns_subsystem_undertow: "urn:jboss:domain:undertow:12.0"
+keycloak_config_ns_subsystem_keycloak: "urn:jboss:domain:keycloak-server:1.1"
+keycloak_config_ns_subsystem_datasource: "urn:jboss:domain:datasources:6.0"
+
 ## Database
-keycloak_postgresql_jdbc_version: "42.2.18"
+keycloak_postgresql_jdbc_version: "42.2.20"
 keycloak_postgresql_jdbc_url: "https://jdbc.postgresql.org/download/postgresql-{{ keycloak_postgresql_jdbc_version }}.jar"
 keycloak_postgresql_host: "localhost"
 keycloak_postgresql_port: "5432"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,8 +4,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:datasources/ns_subsystem:datasource[@jndi-name='java:jboss/datasources/KeycloakDS']"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:datasources:6.0"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_datasources }}"
     pretty_print: true
     set_children:
       - connection-url: "jdbc:postgresql://{{ keycloak_postgresql_host }}:{{ keycloak_postgresql_port }}/{{ keycloak_postgresql_database }}"
@@ -24,8 +24,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:server/ns_subsystem:http-listener[@name='default']"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:undertow:11.0"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_undertow }}"
     attribute: "proxy-address-forwarding"
     value: "true"
   when: keycloak_behind_reverseproxy
@@ -36,8 +36,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:server/ns_subsystem:http-listener[@name='default']"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:undertow:11.0"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_undertow }}"
     attribute: "proxy-address-forwarding"
     value: "false"
   when: not keycloak_behind_reverseproxy
@@ -73,8 +73,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:theme/ns_subsystem:welcomeTheme"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:keycloak-server:1.1"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_keycloak }}"
     value: "{{ keycloak_welcome_theme }}"
   notify: restart keycloak
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -70,8 +70,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:datasources/ns_subsystem:drivers/ns_subsystem:driver[@name='postgresql']"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:datasources:6.0"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_datasources }}"
     count: true
   register: postgresql_jdbc_driver_standalone_count
 
@@ -80,8 +80,8 @@
     path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
     xpath: "/ns_server:server/ns_server:profile/ns_subsystem:subsystem/ns_subsystem:datasources/ns_subsystem:drivers"
     namespaces:
-      ns_server: "urn:jboss:domain:14.0"
-      ns_subsystem: "urn:jboss:domain:datasources:6.0"
+      ns_server: "{{ keycloak_config_ns_server }}"
+      ns_subsystem: "{{ keycloak_config_ns_subsystem_datasources }}"
     pretty_print: true
     add_children:
       - driver:


### PR DESCRIPTION
Upgrade the defaults for Keycloak 13.0.0 and replace hard-coded XML namespaces by variables.  
I also updated the README file.